### PR TITLE
Fix local variable reference error in eval.py

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -37,6 +37,7 @@ def run_eval(args):
              "which may generate unintelligible audio sometimes.")
       print("*******************************")
       path = '%s_ref-randomWeight.wav' % (base_path)
+      alignment_path = '%s_ref-%s-align.png' % (base_path, 'randomWeight')
     else:
       raise ValueError("You must set the reference audio if you don't want to use GSTs.")
 


### PR DESCRIPTION
If we do not specify 'reference_audio' param when use eval.py,
'alignment_path' is referenced before assignment. 
This make execution error during running script eval.py. 

I assign 'alignment_path' if 'reference_audio' is note specified. 